### PR TITLE
fixed paths, logic, and readme regrding the local_dev_data folder

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   },
   "mounts": [
     "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached", // SSH keys
-    "source=/local_dev_data,target=/local_dev_data,type=bind,consistency=cached" // Local development cache
+    "source=${localEnv:HOME}/local_dev_data,target=/local_dev_data,type=bind,consistency=cached" // Local development cache
   ],
   "extensions": [
     "ms-python.flake8",

--- a/.devcontainer/scripts/transfer_local_dev_cache.sh
+++ b/.devcontainer/scripts/transfer_local_dev_cache.sh
@@ -4,4 +4,6 @@ if [ ! -d "/workspaces/mesa_abm_poc/vegetation/.local_dev_data" ]; then
     mkdir /workspaces/mesa_abm_poc/vegetation/.local_dev_data
 fi
 
-cp -r /local_dev_data/mesa_exog_cache/* /workspaces/mesa_abm_poc/vegetation/.local_dev_data
+if [ -d "/local_dev_data/mesa_exog_cache/" ]; then
+    cp -r /local_dev_data/mesa_exog_cache/* /workspaces/mesa_abm_poc/vegetation/.local_dev_data
+fi

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ If going the dev container route, you will need the following:
 - Docker (cli, but optionally the desktop app)
 - VSCode, and the `Dev Containers` extension
 - `ssh` installed on the host machine, to access git from within
+- A folder `local_dev_data` needs to be created in your home directory
 
 After cloning the repo, you will need to open it in VSCode and run the following command:
 


### PR DESCRIPTION
Hi Nick, let's see if that works. I did three things
- fixed the path in `devcontainer.json` such that ` local_dev_data` is looked for in the home directory
- changed `transfer_local_dev_cache.sh` such that it only copies if the folder exists
- added a note on the readme that ` local_dev_data` needs to be created in home. 

About the `.ssh` I am not sure. It worked for me but I already have that folder. Maybe that could be added to the readme, too?

